### PR TITLE
[STEP2-3] Spring REST Docs 스니펫 생성, MockBean 기반 테스트 코드 생성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,10 @@
+import org.asciidoctor.gradle.jvm.AsciidoctorTask
+
 plugins {
     java
     id("org.springframework.boot") version "3.4.1"
     id("io.spring.dependency-management") version "1.1.7"
+    id("org.asciidoctor.jvm.convert") version "4.0.0"
 }
 
 group = "community.whatever"
@@ -18,12 +21,31 @@ repositories {
 }
 
 dependencies {
+
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
+
+
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
+
+val snippetsDir = file("build/generated-snippets")
+
 tasks.withType<Test> {
     useJUnitPlatform()
+    outputs.dir(snippetsDir)
+}
+
+
+
+tasks.named<AsciidoctorTask>("asciidoctor") {
+    dependsOn(tasks.test)
+    inputs.dir(snippetsDir)
+
+    baseDirFollowsSourceFile()
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,15 @@
+= Short URL API 문서
+:toc:
+:snippets: ../../../build/generated-snippets
+
+== 단축 URL 생성
+include::{snippets}/create-short-url/http-request.adoc[]
+include::{snippets}/create-short-url/http-response.adoc[]
+
+== 원본 URL 조회
+include::{snippets}/get-original-url/http-request.adoc[]
+include::{snippets}/get-original-url/http-response.adoc[]
+
+== 잘못된 키 조회 (예외 처리)
+include::{snippets}/get-original-url-invalid-key/http-request.adoc[]
+include::{snippets}/get-original-url-invalid-key/http-response.adoc[]

--- a/src/main/java/community/whatever/onembackendjava/GlobalExceptionHandler.java
+++ b/src/main/java/community/whatever/onembackendjava/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package community.whatever.onembackendjava;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public String handleIllegalArgumentException(IllegalArgumentException ex) {
+        return ex.getMessage();
+    }
+}

--- a/src/test/java/community/whatever/onembackendjava/controller/ShortUrlControllerRestDocsTest.java
+++ b/src/test/java/community/whatever/onembackendjava/controller/ShortUrlControllerRestDocsTest.java
@@ -1,0 +1,66 @@
+
+package community.whatever.onembackendjava.controller;
+
+import community.whatever.onembackendjava.service.ShortUrlService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+@WebMvcTest(ShortUrlController.class)
+@AutoConfigureRestDocs
+class ShortUrlControllerRestDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ShortUrlService shortUrlService;
+
+    @Test
+    void createShortUrl_Docs() throws Exception {
+        when(shortUrlService.createShortUrl(anyString()))
+                .thenReturn("1234");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.post("/short-urls")
+                        .content("https://www.google.com")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().string("1234"))
+                .andDo(document("create-short-url"));
+    }
+
+    @Test
+    void getOriginalUrl_Docs() throws Exception {
+        when(shortUrlService.getOriginalUrl("1234"))
+                .thenReturn("https://www.google.com");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/short-urls/{shortKey}", "1234"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("https://www.google.com"))
+                .andDo(document("get-original-url"));
+    }
+
+    @Test
+    void getOriginalUrl_invalidKey_Docs() throws Exception {
+        // 모든 문자열에 대해 예외를 던지도록 설정
+        when(shortUrlService.getOriginalUrl(Mockito.anyString()))
+                .thenThrow(new IllegalArgumentException("Invalid key"));
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/short-urls/{shortKey}", "9999"))
+                // 404(Not Found) 상태 반환
+                .andExpect(status().isNotFound())
+                .andDo(document("get-original-url-invalid-key"));
+    }
+
+}


### PR DESCRIPTION
- Spring REST Docs 스니펫을 생성 했습니다.
- 스니펫 생성을 위해서 통합 테스트는 별도로 두고 mockMvc 테스트 코드를 추가하였습니다.
- MockMvc 테스트시 500에러 상황을 처리하기 위해 404 핸들러를 추가했습니다.

![3463463463463463463463464363](https://github.com/user-attachments/assets/d37ffd64-3056-410a-b80a-ce548c8b2122)

Swagger 대신에 사용할만한 무언가가 있을까 찾아보다가 REST Docs를 찾아서 적용해 봤습니다.

mockMvc 테스트를 통해 스니펫을 생성하고 html에 업데이트 되게 설정 했습니다.
