### PR TITLE
[STEP2-4] feat: 단축 URL 서비스 - 차단 도메인 기능 추가 및 application.yml 설정 업데이트

### DIFF
--- a/src/main/java/community/whatever/onembackendjava/service/ShortUrlService.java
+++ b/src/main/java/community/whatever/onembackendjava/service/ShortUrlService.java
@@ -1,8 +1,12 @@
 package community.whatever.onembackendjava.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
@@ -10,9 +14,17 @@ import java.util.Random;
 public class ShortUrlService {
 
     private final Map<String, String> urlMappings = new HashMap<>();
+    private final Random random = new Random();
+
+    @Value("#{'${shortener.blocked-domains}'.split(',')}")
+    private List<String> blockedDomains;
 
     public String createShortUrl(String originalUrl) {
-        String shortKey = String.valueOf(new Random().nextInt(10000));
+
+        if (isBlockedDomain(originalUrl)) {
+            throw new IllegalArgumentException("Short URL 제공이 거부된 도메인입니다.");
+        }
+        String shortKey = String.valueOf(random.nextInt(10000));
         urlMappings.put(shortKey, originalUrl);
         return shortKey;
     }
@@ -22,5 +34,21 @@ public class ShortUrlService {
             throw new IllegalArgumentException("Invalid key");
         }
         return urlMappings.get(shortKey);
+    }
+
+    private boolean isBlockedDomain(String originalUrl) {
+        try {
+            URL url = new URL(originalUrl);
+            String host = url.getHost().toLowerCase();
+            for (String blocked : blockedDomains) {
+
+                if (host.equals(blocked.trim().toLowerCase()) || host.endsWith("." + blocked.trim().toLowerCase())) {
+                    return true;
+                }
+            }
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid URL format", e);
+        }
+        return false;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,10 @@
-spring.application.name=onem-backend-java
+spring:
+  application:
+    name: onem-backend-java
+
+shortener:
+  endpoint:
+    create: /short-urls
+    search: /short-urls/{shortKey}
+  blocked-domains:
+    - naver.com


### PR DESCRIPTION
## 변경 내용 (What):

1. application.yml 설정 업데이트
- 기존 spring.application.name 설정은 그대로 유지하고, 새로운 shortener 섹션을 추가하여 단축 URL 관련 엔드포인트를 설정했습니다.
- 구체적으로, shortener.endpoint.create를 /short-urls로, shortener.endpoint.search를 /short-urls/{shortKey}로 지정했습니다.
- 또한, 차단할 도메인 목록을 shortener.blocked-domains 항목으로 관리하도록 추가하였으며, 예시로 naver.com을 차단 목록에 포함시켰습니다.
- 
2. ShortUrlService 수정
- ShortUrlService에 프로퍼티를 통해 차단 도메인 목록을 주입받아 관리하도록 변경했습니다.
- createShortUrl 메서드 내에서, 원본 URL의 도메인을 추출하고 차단 목록과 비교하여, 차단 도메인에 해당하는 경우 IllegalArgumentException("Short URL 제공이 거부된 도메인입니다.")를 발생시킵니다.