### PR TITLE
[STEP3-2] 부하테스트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,11 @@ services:
       - mysql
     networks:
       - shortenurl-network
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: "1GB"
 
   mysql:
     image: mysql:8.0.41
@@ -56,11 +61,7 @@ services:
       - "3306:3306"
     networks:
       - shortenurl-network
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: "1GB"
+
 
   influxdb:
     image: influxdb:1.8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       - "3000:3000"
     networks:
       - shortenurl-network
+    depends_on:
+      - influxdb
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
 
   node-exporter:
     image: prom/node-exporter:latest
@@ -51,7 +56,30 @@ services:
       - "3306:3306"
     networks:
       - shortenurl-network
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: "1GB"
+
+  influxdb:
+    image: influxdb:1.8
+    container_name: influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+      - INFLUXDB_ADMIN_USER=admin
+      - INFLUXDB_ADMIN_PASSWORD=admin
+      - INFLUXDB_HTTP_AUTH_ENABLED=false
+    networks:
+      - shortenurl-network
+    volumes:
+      - influxdb_data:/var/lib/influxdb
 
 networks:
   shortenurl-network:
     driver: bridge
+
+volumes:
+  influxdb_data:

--- a/k6-scripts/get-origin-url.js
+++ b/k6-scripts/get-origin-url.js
@@ -7,7 +7,7 @@ export const options = {
 };
 
 export default function () {
-  const url = 'http://localhost:8080/shorten-url/dev-5WA6u1G3JILf';
+  const url = 'http://localhost:8080/shorten-url/dev-iBbJapCOAX0G';
 
   // GET 요청 보내기
   http.get(url);

--- a/k6-scripts/get-origin-url.js
+++ b/k6-scripts/get-origin-url.js
@@ -1,0 +1,14 @@
+import http from 'k6/http';
+
+export const options = {
+  stages: [
+    { duration: '30s', target: 1000 },
+  ],
+};
+
+export default function () {
+  const url = 'http://localhost:8080/shorten-url/dev-5WA6u1G3JILf';
+
+  // GET 요청 보내기
+  http.get(url);
+}

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/component/ShortenUrlKeyGenerator.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/component/ShortenUrlKeyGenerator.java
@@ -1,4 +1,4 @@
-package community.whatever.onembackendjava.urlshorten.component;
+package community.whatever.onembackendjava.shortenurl.component;
 
 import java.util.Base64;
 import org.springframework.core.env.Environment;

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/component/ShortenUrlValidator.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/component/ShortenUrlValidator.java
@@ -1,8 +1,8 @@
-package community.whatever.onembackendjava.urlshorten.component;
+package community.whatever.onembackendjava.shortenurl.component;
 
 import community.whatever.onembackendjava.common.exception.ErrorCode;
 import community.whatever.onembackendjava.common.exception.custom.ValidationException;
-import community.whatever.onembackendjava.urlshorten.properties.ShortenUrlProperties;
+import community.whatever.onembackendjava.shortenurl.properties.ShortenUrlProperties;
 import java.net.MalformedURLException;
 import java.net.URL;
 import org.springframework.stereotype.Component;

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/controller/ShortenUrlController.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/controller/ShortenUrlController.java
@@ -1,9 +1,9 @@
-package community.whatever.onembackendjava.urlshorten.controller;
+package community.whatever.onembackendjava.shortenurl.controller;
 
-import community.whatever.onembackendjava.urlshorten.dto.OriginUrlResponse;
-import community.whatever.onembackendjava.urlshorten.dto.ShortenUrlRequest;
-import community.whatever.onembackendjava.urlshorten.dto.ShortenUrlResponse;
-import community.whatever.onembackendjava.urlshorten.service.ShortenUrlService;
+import community.whatever.onembackendjava.shortenurl.dto.OriginUrlResponse;
+import community.whatever.onembackendjava.shortenurl.dto.ShortenUrlRequest;
+import community.whatever.onembackendjava.shortenurl.dto.ShortenUrlResponse;
+import community.whatever.onembackendjava.shortenurl.service.ShortenUrlService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/dto/OriginUrlResponse.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/dto/OriginUrlResponse.java
@@ -1,4 +1,4 @@
-package community.whatever.onembackendjava.urlshorten.dto;
+package community.whatever.onembackendjava.shortenurl.dto;
 
 public record OriginUrlResponse(
     String originUrl

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/dto/ShortenUrlRequest.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/dto/ShortenUrlRequest.java
@@ -1,4 +1,4 @@
-package community.whatever.onembackendjava.urlshorten.dto;
+package community.whatever.onembackendjava.shortenurl.dto;
 
 public record ShortenUrlRequest(
     String originUrl

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/dto/ShortenUrlResponse.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/dto/ShortenUrlResponse.java
@@ -1,4 +1,4 @@
-package community.whatever.onembackendjava.urlshorten.dto;
+package community.whatever.onembackendjava.shortenurl.dto;
 
 public record ShortenUrlResponse (
     String shortenUrlKey

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/entity/ShortenUrl.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/entity/ShortenUrl.java
@@ -1,4 +1,4 @@
-package community.whatever.onembackendjava.urlshorten.domain;
+package community.whatever.onembackendjava.shortenurl.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/properties/ShortenUrlProperties.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/properties/ShortenUrlProperties.java
@@ -1,4 +1,4 @@
-package community.whatever.onembackendjava.urlshorten.properties;
+package community.whatever.onembackendjava.shortenurl.properties;
 
 import java.time.Duration;
 import java.util.Set;

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/repository/ShortenUrlRepository.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/repository/ShortenUrlRepository.java
@@ -1,6 +1,6 @@
-package community.whatever.onembackendjava.urlshorten.repository;
+package community.whatever.onembackendjava.shortenurl.repository;
 
-import community.whatever.onembackendjava.urlshorten.domain.ShortenUrl;
+import community.whatever.onembackendjava.shortenurl.entity.ShortenUrl;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/community/whatever/onembackendjava/shortenurl/service/ShortenUrlService.java
+++ b/src/main/java/community/whatever/onembackendjava/shortenurl/service/ShortenUrlService.java
@@ -1,13 +1,13 @@
-package community.whatever.onembackendjava.urlshorten.service;
+package community.whatever.onembackendjava.shortenurl.service;
 
 import community.whatever.onembackendjava.common.exception.ErrorCode;
 import community.whatever.onembackendjava.common.exception.custom.ExpiredUrlException;
 import community.whatever.onembackendjava.common.exception.custom.NotFoundException;
-import community.whatever.onembackendjava.urlshorten.component.ShortenUrlKeyGenerator;
-import community.whatever.onembackendjava.urlshorten.component.ShortenUrlValidator;
-import community.whatever.onembackendjava.urlshorten.domain.ShortenUrl;
-import community.whatever.onembackendjava.urlshorten.properties.ShortenUrlProperties;
-import community.whatever.onembackendjava.urlshorten.repository.ShortenUrlRepository;
+import community.whatever.onembackendjava.shortenurl.component.ShortenUrlKeyGenerator;
+import community.whatever.onembackendjava.shortenurl.component.ShortenUrlValidator;
+import community.whatever.onembackendjava.shortenurl.entity.ShortenUrl;
+import community.whatever.onembackendjava.shortenurl.properties.ShortenUrlProperties;
+import community.whatever.onembackendjava.shortenurl.repository.ShortenUrlRepository;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.stereotype.Service;

--- a/src/test/java/community/whatever/onembackendjava/shortenurl/service/ShortenUrlServiceTest.java
+++ b/src/test/java/community/whatever/onembackendjava/shortenurl/service/ShortenUrlServiceTest.java
@@ -1,4 +1,4 @@
-package community.whatever.onembackendjava.urlshorten.service;
+package community.whatever.onembackendjava.shortenurl.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -7,8 +7,8 @@ import community.whatever.onembackendjava.common.exception.ErrorCode;
 import community.whatever.onembackendjava.common.exception.custom.NotFoundException;
 import community.whatever.onembackendjava.common.exception.custom.ExpiredUrlException;
 import community.whatever.onembackendjava.common.exception.custom.ValidationException;
-import community.whatever.onembackendjava.urlshorten.domain.ShortenUrl;
-import community.whatever.onembackendjava.urlshorten.repository.ShortenUrlRepository;
+import community.whatever.onembackendjava.shortenurl.entity.ShortenUrl;
+import community.whatever.onembackendjava.shortenurl.repository.ShortenUrlRepository;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
**부하테스트**

* influxdb, grafana를 이용해 k6의 결과를 시각화하였습니다.
* shortenurl 컨테이너의 cpu, memory limits를 1.0, 1GB로 설정한 후 테스트하였습니다.
* SQL을 통해 10만건의 더미데이터를 삽입한 후 테스트하였습니다.


**테스트 시나리오**

**생성된 shortenUrlKey를 통해 OriginUrl을 조회**

1. 가상 유저 1000명, 30초의 부하, shortenUrlKey에 index 설정 x
2. 가상 유저 1000명, 30초의 부하, shortenUrlKey에 index 설정 o

**테스트 결과**

**가상 유저 1000명, 30초의 부하, shortenUrlKey에 index 설정 x**
- 5561개의 요청 수
- http_req_duration : 평균 3.28s

**가상 유저 1000명, 30초의 부하, shortenUrlKey에 index 설정 o**
- 67641개의 요청 수
- http_req_duration : 평균 225.66ms

**궁금한 점**

1. 인프라 환경을 shorten-url 인스턴스와 모니터링 관련 인스턴스, RDS를 사용한다고 가정하고, docker-compose.yml 파일에 shorten-url 컨테이너의 cpu와 memory를 1.0, 1GB로 설정하였는데 정상적인 테스트 환경이 설정된 것이 맞는지 궁금합니다.

2. 실무에서 부하 테스트 시나리오를 설정할 때 호출 빈도와 응답 시간에 대한 기준은 어떤 조건에 의해 정해지는지 궁금합니다.


